### PR TITLE
feat: support only 2 value (O2V) version dereference table.

### DIFF
--- a/src/chained_ht_64.cpp
+++ b/src/chained_ht_64.cpp
@@ -1,0 +1,53 @@
+#include <cstdlib>
+#include <cstring>
+#include "chained_ht_64.h"
+
+namespace tinyptr {
+
+ChainedHT64::ChainedHT64(int n) {
+    deref_tab = new DereferenceTable64(n);
+    quot_tab = new uint8_t[1 << kQuotientingTailSize];
+    memset(quot_tab, 0, sizeof(uint8_t) * (1 << kQuotientingTailSize));
+
+    quot_head_hash =
+        std::function<uint32_t(uint64_t)>([](uint64_t key) -> uint32_t {
+            return XXHash64::hash(&key, sizeof(uint64_t), rand()) &
+                   ((1 << kQuotientingTailSize) - 1);
+        });
+}
+
+uint32_t ChainedHT64::get_bin_num(uint64_t key) {
+    return (quot_head_hash(key) ^ key) & ((1 << kQuotientingTailSize) - 1);
+}
+
+uint64_t ChainedHT64::encode_key(uint64_t key) {
+    return key >> kQuotientingTailSize;
+}
+
+uint64_t ChainedHT64::decode_key(uint64_t quot_key, uint32_t bin_num) {
+    uint64_t quot_head = quot_key << kQuotientingTailSize;
+    return quot_head | (bin_num ^ quot_head_hash(quot_head));
+}
+
+bool ChainedHT64::ContainsKey(uint64_t key) {
+    // return deref_tab.Query(key, uint8_t ptr, uint64_t* value_ptr);
+}
+
+bool ChainedHT64::Insert(uint64_t key, uint64_t value) {
+    uint32_t bin_num = get_bin_num(key);
+    
+    uint8_t ptr = quot_tab[bin_num];
+
+    while(ptr)
+    {
+
+    }
+}
+
+bool ChainedHT64::Erase(uint64_t key) {}
+
+bool ChainedHT64::Update(uint64_t key, uint64_t value) {}
+
+uint64_t ChainedHT64::Query(uint64_t key) {}
+
+}  // namespace tinyptr

--- a/src/chained_ht_64.h
+++ b/src/chained_ht_64.h
@@ -1,0 +1,37 @@
+#include <functional>
+#include "common.h"
+#include "dereference_table_64.h"
+
+namespace tinyptr {
+
+class ChainedHT64 {
+   public:
+    static constexpr uint64_t kQuotientingTailSize = 20;
+    static constexpr uint64_t kQuotientingHeadSize = 44;
+
+   public:
+    ChainedHT64() = delete;
+    ChainedHT64(int n);
+    ~ChainedHT64() = default;
+
+   private:
+    uint32_t get_bin_num(uint64_t key);
+    uint64_t encode_key(uint64_t key);
+    uint64_t decode_key(uint64_t quot_key, uint32_t bin_num);
+
+   public:
+    bool ContainsKey(uint64_t key);
+
+   public:
+    bool Insert(uint64_t key, uint64_t value);
+    bool Erase(uint64_t key);
+    bool Update(uint64_t key, uint64_t value);
+    uint64_t Query(uint64_t key);
+    // TODO: or not todo? supporting iterator & key/value set & vectorized operators
+
+   private:
+    std::function<uint32_t(uint64_t)> quot_head_hash;
+    DereferenceTable64* deref_tab;
+    uint8_t* quot_tab;
+};
+}  // namespace tinyptr

--- a/src/o2v_dereference_table_64.cpp
+++ b/src/o2v_dereference_table_64.cpp
@@ -1,0 +1,66 @@
+#include "o2v_dereference_table_64.h"
+#include "o2v_overflow_table.h"
+#include "o2v_po2c_table.h"
+
+namespace tinyptr {
+
+O2VDereferenceTable64::O2VDereferenceTable64(int n) {
+    p_tab = new O2VPo2CTable(n);
+    o_tab = new O2VOverflowTable;
+}
+
+uint8_t O2VDereferenceTable64::Allocate(uint64_t key, uint64_t value_1,
+                                        uint64_t value_2) {
+    if (uint8_t ptr = p_tab->Allocate(key, value_1, value_2)) {
+        if (ptr == kOverflowTinyPtr)
+            return o_tab->Allocate(key, value_1, value_2);
+        return ptr;
+    }
+    return 0;
+}
+
+void O2VDereferenceTable64::UpdateFirst(uint64_t key, uint8_t ptr,
+                                        uint64_t value) {
+    assert(ptr);
+
+    if (ptr == kOverflowTinyPtr)
+        o_tab->UpdateFirst(key, value);
+    p_tab->UpdateFirst(key, ptr, value);
+}
+
+void O2VDereferenceTable64::UpdateSecond(uint64_t key, uint8_t ptr,
+                                         uint64_t value) {
+    assert(ptr);
+
+    if (ptr == kOverflowTinyPtr)
+        o_tab->UpdateSecond(key, value);
+    p_tab->UpdateSecond(key, ptr, value);
+}
+
+void O2VDereferenceTable64::QueryFirst(uint64_t key, uint8_t ptr,
+                                       uint64_t* value_ptr) {
+    assert(ptr);
+
+    if (ptr == kOverflowTinyPtr)
+        o_tab->QueryFirst(key, value_ptr);
+    p_tab->QueryFirst(key, ptr, value_ptr);
+}
+
+void O2VDereferenceTable64::QuerySecond(uint64_t key, uint8_t ptr,
+                                        uint64_t* value_ptr) {
+    assert(ptr);
+
+    if (ptr == kOverflowTinyPtr)
+        o_tab->QuerySecond(key, value_ptr);
+    p_tab->QuerySecond(key, ptr, value_ptr);
+}
+
+void O2VDereferenceTable64::Free(uint64_t key, uint8_t ptr) {
+    assert(ptr);
+
+    if (ptr == kOverflowTinyPtr)
+        return o_tab->Free(key);
+    return p_tab->Free(key, ptr);
+}
+
+}  // namespace tinyptr

--- a/src/o2v_dereference_table_64.h
+++ b/src/o2v_dereference_table_64.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+
+#include "common.h"
+#include "dereference_table.h"
+
+namespace tinyptr {
+
+class O2VPo2CTable;
+class O2VOverflowTable;
+
+class O2VDereferenceTable64 : DereferenceTable {
+
+   public:
+    static constexpr size_t kBinSize = 127;
+    static constexpr uint8_t kNullTinyPtr = 0;
+    static constexpr uint8_t kOverflowTinyPtr = ((1 << 8) - 1);
+
+   public:
+    O2VDereferenceTable64() = delete;
+    O2VDereferenceTable64(int n);
+    ~O2VDereferenceTable64() = default;
+
+    uint8_t Allocate(uint64_t key, uint64_t value_1, uint64_t value_2);
+    void UpdateFirst(uint64_t key, uint8_t ptr, uint64_t value);
+    void UpdateSecond(uint64_t key, uint8_t ptr, uint64_t value);
+    void QueryFirst(uint64_t key, uint8_t ptr, uint64_t* value_ptr);
+    void QuerySecond(uint64_t key, uint8_t ptr, uint64_t* value_ptr);
+    void Free(uint64_t key, uint8_t ptr);
+
+   private:
+    O2VPo2CTable* p_tab;
+    O2VOverflowTable* o_tab;
+};
+
+}  // namespace tinyptr

--- a/src/o2v_overflow_table.cpp
+++ b/src/o2v_overflow_table.cpp
@@ -1,0 +1,30 @@
+#include "o2v_overflow_table.h"
+
+namespace tinyptr {
+
+uint8_t O2VOverflowTable::Allocate(uint64_t key, uint64_t value_1,
+                                   uint64_t value_2) {
+    tab[key] = VV{value_1, value_2};
+    return ~0;
+}
+
+void O2VOverflowTable::UpdateFirst(uint64_t key, uint64_t value) {
+    tab[key].value_1 = value;
+}
+
+void O2VOverflowTable::UpdateSecond(uint64_t key, uint64_t value) {
+    tab[key].value_2 = value;
+}
+
+void O2VOverflowTable::QueryFirst(uint64_t key, uint64_t* value_ptr) {
+    *value_ptr = tab[key].value_1;
+}
+
+void O2VOverflowTable::QuerySecond(uint64_t key, uint64_t* value_ptr) {
+    *value_ptr = tab[key].value_2;
+}
+
+void O2VOverflowTable::Free(uint64_t key) {
+    tab.erase(key);
+}
+}  // namespace tinyptr

--- a/src/o2v_overflow_table.h
+++ b/src/o2v_overflow_table.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <cstdint>
+#include <cstdlib>
+#include <map>
+
+namespace tinyptr {
+class O2VOverflowTable {
+   private:
+    struct VV {
+        uint64_t value_1, value_2;
+    };
+
+   public:
+    O2VOverflowTable() = default;
+    ~O2VOverflowTable() = default;
+
+   public:
+    uint8_t Allocate(uint64_t key, uint64_t value_1, uint64_t value_2);
+    void UpdateFirst(uint64_t key, uint64_t value);
+    void UpdateSecond(uint64_t key, uint64_t value);
+    void QueryFirst(uint64_t key, uint64_t* value_ptr);
+    void QuerySecond(uint64_t key, uint64_t* value_ptr);
+    void Free(uint64_t key);
+
+   private:
+    std::map<uint64_t, VV> tab;
+};
+}  // namespace tinyptr

--- a/src/o2v_po2c_table.cpp
+++ b/src/o2v_po2c_table.cpp
@@ -1,0 +1,153 @@
+#include "o2v_po2c_table.h"
+
+namespace tinyptr {
+
+O2VPo2CTable::Bin::Bin() {
+    for (int i = 0; i < O2VDereferenceTable64::kBinSize; ++i)
+        bin[i].value_1 = i + 2;
+}
+
+bool O2VPo2CTable::Bin::full() {
+    return cnt == O2VDereferenceTable64::kBinSize;
+}
+
+uint8_t O2VPo2CTable::Bin::count() {
+    return cnt;
+}
+
+void O2VPo2CTable::Bin::query_first(uint8_t ptr, uint64_t* value_ptr) {
+    assert(ptr < (1 << 7));
+    assert(ptr);
+    --ptr;
+
+    *value_ptr = bin[ptr].value_1;
+}
+
+void O2VPo2CTable::Bin::query_second(uint8_t ptr, uint64_t* value_ptr) {
+    assert(ptr < (1 << 7));
+    assert(ptr);
+    --ptr;
+
+    *value_ptr = bin[ptr].value_2;
+}
+
+// ~0 for full bin
+// i+1 for position i
+uint8_t O2VPo2CTable::Bin::insert(uint64_t value_1, uint64_t value_2) {
+    if (this->full())
+        return ~0;
+
+    ++cnt;
+    auto tmp = head;
+    head = bin[head - 1].value_1;
+    bin[tmp - 1].value_1 = value_1;
+    bin[tmp - 1].value_2 = value_2;
+
+    return tmp;
+}
+
+void O2VPo2CTable::Bin::update_first(uint8_t ptr, uint64_t value) {
+    assert(ptr < (1 << 7));
+    assert(ptr);
+    --ptr;
+
+    bin[ptr].value_1 = value;
+}
+
+void O2VPo2CTable::Bin::update_second(uint8_t ptr, uint64_t value) {
+    assert(ptr < (1 << 7));
+    assert(ptr);
+    --ptr;
+
+    bin[ptr].value_2 = value;
+}
+
+void O2VPo2CTable::Bin::free(uint8_t ptr) {
+    assert(ptr < (1 << 7));
+    assert(ptr);
+    --ptr;
+
+    bin[ptr].value_1 = head;
+    head = ptr + 1;
+    --cnt;
+}
+
+O2VPo2CTable::O2VPo2CTable(int n) {
+    bin_num =
+        (n + O2VDereferenceTable64::kBinSize - 1) / O2VDereferenceTable64::kBinSize;
+    tab = new Bin[bin_num];
+    srand(time(0));
+    int hash_seed[2] = {rand(), rand()};
+    while (hash_seed[1] == hash_seed[0])
+        hash_seed[1] = rand();
+    for (int i = 0; i < 2; ++i)
+        HashBin[i] =
+            std::function<uint64_t(uint64_t)>([=](uint64_t key) -> uint64_t {
+                return XXHash64::hash(&key, sizeof(uint64_t), hash_seed[i]) %
+                       bin_num;
+            });
+}
+
+uint8_t O2VPo2CTable::Allocate(uint64_t key, uint64_t value_1, uint64_t value_2) {
+    uint64_t hashbin[2];
+    for (int i = 0; i < 2; ++i) {
+        hashbin[i] = HashBin[i](key);
+    }
+
+    uint8_t flag = tab[hashbin[0]].count() > tab[hashbin[1]].count();
+
+    uint8_t ptr = tab[hashbin[flag]].insert(value_1, value_2);
+    
+    assert(ptr);
+
+    ptr ^=
+        flag * (ptr != O2VDereferenceTable64::kOverflowTinyPtr) * ((1 << 8) - 1);
+    return ptr;
+}
+
+void O2VPo2CTable::UpdateFirst(uint64_t key, uint8_t ptr, uint64_t value) {
+    assert(ptr != O2VDereferenceTable64::kOverflowTinyPtr);
+    assert(ptr != O2VDereferenceTable64::kNullTinyPtr);
+
+    uint8_t flag = (ptr >= (1 << 7));
+    ptr ^= flag * ((1 << 8) - 1);
+    tab[HashBin[flag](key)].update_first(ptr, value);
+}
+
+void O2VPo2CTable::UpdateSecond(uint64_t key, uint8_t ptr, uint64_t value) {
+    assert(ptr != O2VDereferenceTable64::kOverflowTinyPtr);
+    assert(ptr != O2VDereferenceTable64::kNullTinyPtr);
+
+    uint8_t flag = (ptr >= (1 << 7));
+    ptr ^= flag * ((1 << 8) - 1);
+    tab[HashBin[flag](key)].update_second(ptr, value);
+}
+
+void O2VPo2CTable::QueryFirst(uint64_t key, uint8_t ptr, uint64_t* value_ptr) {
+    assert(ptr != O2VDereferenceTable64::kOverflowTinyPtr);
+    assert(ptr != O2VDereferenceTable64::kNullTinyPtr);
+
+    uint8_t flag = (ptr >= (1 << 7));
+    ptr ^= flag * ((1 << 8) - 1);
+    tab[HashBin[flag](key)].query_first(ptr, value_ptr);
+}
+
+void O2VPo2CTable::QuerySecond(uint64_t key, uint8_t ptr, uint64_t* value_ptr) {
+    assert(ptr != O2VDereferenceTable64::kOverflowTinyPtr);
+    assert(ptr != O2VDereferenceTable64::kNullTinyPtr);
+
+    uint8_t flag = (ptr >= (1 << 7));
+    ptr ^= flag * ((1 << 8) - 1);
+    tab[HashBin[flag](key)].query_second(ptr, value_ptr);
+}
+
+void O2VPo2CTable::Free(uint64_t key, uint8_t ptr) {
+    assert(ptr != O2VDereferenceTable64::kOverflowTinyPtr);
+    assert(ptr != O2VDereferenceTable64::kNullTinyPtr);
+
+    uint8_t flag = (ptr >= (1 << 7));
+    ptr ^= flag * ((1 << 8) - 1);
+    tab[HashBin[flag](key)].free(ptr);
+}
+
+}  // namespace tinyptr

--- a/src/o2v_po2c_table.h
+++ b/src/o2v_po2c_table.h
@@ -1,0 +1,59 @@
+#pragma once
+
+#include <bitset>
+#include <cassert>
+#include <cstdlib>
+#include <functional>
+#include <map>
+#include "common.h"
+#include "o2v_dereference_table_64.h"
+#include "xxhash64.h"
+
+namespace tinyptr {
+class O2VPo2CTable {
+   private:
+    struct VV {
+        uint64_t value_1, value_2;
+    };
+
+    class Bin {
+       public:
+        Bin();
+        ~Bin() = default;
+
+       public:
+        bool full();
+        uint8_t count();
+        void query_first(uint8_t ptr, uint64_t* value_ptr);
+        void query_second(uint8_t ptr, uint64_t* value_ptr);
+        uint8_t insert(uint64_t value_1, uint64_t value_2);
+        void update_first(uint8_t ptr, uint64_t value);
+        void update_second(uint8_t ptr, uint64_t value);
+        void free(uint8_t ptr);
+
+       private:
+        uint8_t cnt = 0;
+        uint8_t head = 1;
+        VV bin[O2VDereferenceTable64::kBinSize];
+    };
+
+   public:
+    O2VPo2CTable() = delete;
+
+    O2VPo2CTable(int n);
+
+    ~O2VPo2CTable() = default;
+
+    uint8_t Allocate(uint64_t key, uint64_t value_1, uint64_t value_2);
+    void UpdateFirst(uint64_t key, uint8_t ptr, uint64_t value);
+    void UpdateSecond(uint64_t key, uint8_t ptr, uint64_t value);
+    void QueryFirst(uint64_t key, uint8_t ptr, uint64_t* value_ptr);
+    void QuerySecond(uint64_t key, uint8_t ptr, uint64_t* value_ptr);
+    void Free(uint64_t key, uint8_t ptr);
+
+   private:
+    std::function<uint64_t(uint64_t)> HashBin[2];
+    uint64_t bin_num;
+    Bin* tab;
+};
+}  // namespace tinyptr


### PR DESCRIPTION
this will enable arbitrarily modifying the content within the dereference table, but also loses the field of key. we're using it in the chained hash table, where the key info is externally assured and the dereference table does not store the key directly.